### PR TITLE
FEAT: Attempts to leverage Splide lazyloading for large slider images.

### DIFF
--- a/app/ui/slider/slider.jsx
+++ b/app/ui/slider/slider.jsx
@@ -86,6 +86,7 @@ const Slider = ({slidesArray}) => {
                   sizes='100vw'
                   priority={index === 0}
                   lazyload={(index === 2 || index === 3).toString()}
+                  data-splide-lazy={slide.imageURL}
                 />
               </>
             )
@@ -118,6 +119,7 @@ const Slider = ({slidesArray}) => {
     autoplay : true,
     rewind : true,
     height: '100vh',
+    lazyload: 'sequential',
     breakpoints: {
       679: {
         height: '540px',


### PR DESCRIPTION
Attempts to leverage Splide lazyloading for large slider images by
> Adding Lazy Loading option to Slider options
> Adding `data-splide-lazy` to images (I'm nto sure how effective this will be given images are implemented by next/image